### PR TITLE
Preliminary support for local LLM endpoints (tested on Ollama)

### DIFF
--- a/dailalib/__init__.py
+++ b/dailalib/__init__.py
@@ -30,6 +30,8 @@ def create_plugin(*args, **kwargs):
     gui_ctx_menu_actions["DAILA/LLM/Settings/update_api_key"] = ("Update API key...", litellm_api.ask_api_key)
     gui_ctx_menu_actions["DAILA/LLM/Settings/update_pmpt_style"] = ("Change prompt style...", litellm_api.ask_prompt_style)
     gui_ctx_menu_actions["DAILA/LLM/Settings/update_model"] = ("Change model...", litellm_api.ask_model)
+    gui_ctx_menu_actions["DAILA/LLM/Settings/update_custom_url"] = ("Set Custom OpenAI Endpoint...", litellm_api.ask_custom_endpoint)
+    gui_ctx_menu_actions["DAILA/LLM/Settings/update_custom_model"] = ("Set Custom OpenAI Model...", litellm_api.ask_custom_model)
 
     #
     # VarModel API (local variable renaming)

--- a/dailalib/api/litellm/litellm_api.py
+++ b/dailalib/api/litellm/litellm_api.py
@@ -36,6 +36,8 @@ class LiteLLMAIAPI(AIAPI):
         fit_to_tokens: bool = False,
         chat_use_ctx: bool = True,
         chat_event_callbacks: Optional[dict] = None,
+        custom_endpoint: Optional[str] = None,
+        custom_model: Optional[str] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -47,6 +49,8 @@ class LiteLLMAIAPI(AIAPI):
         self.fit_to_tokens = fit_to_tokens
         self.chat_use_ctx = chat_use_ctx
         self.chat_event_callbacks = chat_event_callbacks or {"send": None, "receive": None}
+        self.custom_endpoint = custom_endpoint
+        self.custom_model = custom_model
 
         # delay prompt import
         from .prompts import PROMPTS
@@ -79,10 +83,10 @@ class LiteLLMAIAPI(AIAPI):
         # delay import because litellm attempts to query the server on import to collect cost information.
         from litellm import completion
 
-        if not self.api_key:
+        if not self.api_key and not self.custom_endpoint:
             raise ValueError(f"Model API key is not set. Please set it before querying the model {self.model}")
 
-        prompt_model = model or self.model
+        prompt_model = (model or self.model) if not self.custom_endpoint else self.custom_model
         response = completion(
             model=prompt_model,
             messages=[
@@ -90,12 +94,17 @@ class LiteLLMAIAPI(AIAPI):
             ],
             max_tokens=max_tokens,
             timeout=60,
+            api_base=self.custom_endpoint if self.custom_endpoint else None,  # Use custom endpoint if set
+            api_key="dummy" if self.custom_endpoint and not self.api_key else self.api_key # In most of cases custom endpoint doesn't need the api_key
         )
         # get the answer
         try:
             answer = response.choices[0].message.content
         except (KeyError, IndexError) as e:
             answer = None
+
+        if self.custom_endpoint:
+            return answer, 0
 
         # get the estimated cost
         try:
@@ -189,7 +198,7 @@ class LiteLLMAIAPI(AIAPI):
                 os.environ["ANTHROPIC_API_KEY"] = self._api_key
             elif "gemini/gemini" in self.model:
                 os.environ["GEMINI_API_KEY"] = self._api_key
-            elif "perplexity" in self.model: 
+            elif "perplexity" in self.model:
                 os.environ["PERPLEXITY_API_KEY"] = self._api_key
 
     def ask_api_key(self, *args, **kwargs):
@@ -201,6 +210,17 @@ class LiteLLMAIAPI(AIAPI):
         else:
             api_key = api_key_or_path
         self.api_key = api_key
+
+    def ask_custom_endpoint(self, *args, **kwargs):
+        custom_endpoint = self._dec_interface.gui_ask_for_string("Enter your custom OpenAI endpoint:", title="DAILA")
+        # TODO verify the input
+        self.custom_endpoint = custom_endpoint
+        self._dec_interface.info(f"Custom endpoint set to {self.custom_endpoint}")
+
+    def ask_custom_model(self, *args, **kwargs):
+        custom_model = self._dec_interface.gui_ask_for_string("Enter your custom OpenAI model name:", title="DAILA")
+        self.custom_model = "openai/" + custom_model
+        self._dec_interface.info(f"Custom model set to {self.custom_model}")
 
     def _set_prompt_style(self, prompt_style):
         self.prompt_style = prompt_style


### PR DESCRIPTION
A working preliminary implementation tested on Ollama (feature request #66).
Added two GUI configuration entries. If the endpoint URL is set, then the cost is not calculated, and instead of model from dropdown, the custom model name is used.
Test example:
Custom endpoint - "http://localhost:11434/v1"
Custom model - "qwen2.5-coder:32b-instruct-q6_K"