### PR TITLE
Small improvements for running local models

### DIFF
--- a/dailalib/api/litellm/litellm_api.py
+++ b/dailalib/api/litellm/litellm_api.py
@@ -93,13 +93,14 @@ class LiteLLMAIAPI(AIAPI):
                 {"role": "user", "content": prompt}
             ],
             max_tokens=max_tokens,
-            timeout=60,
+            timeout=60 if not self.custom_endpoint else 300,
             api_base=self.custom_endpoint if self.custom_endpoint else None,  # Use custom endpoint if set
             api_key=self.api_key if not self.custom_endpoint else "dummy" # In most of cases custom endpoint doesn't need the api_key
         )
         # get the answer
         try:
             answer = response.choices[0].message.content
+            if self.custom_endpoint: print(answer)
         except (KeyError, IndexError) as e:
             answer = None
 


### PR DESCRIPTION
Some really big models on large context can take more than default 60 seconds to process the request, hence hitting the timeout. This value was bumped to 5 minutes for local models.
Also added response print to the terminal window, as the "Suggest a function name" sometimes does not work with local models when they do not adhere correctly to this prompt
```
## Answer
{
    "FUN_004dba38": "handle_input_and_read",
    "FTD2XX_FT_Read": "read_from_device",
}
```